### PR TITLE
Call onLoad after awaiting fridaScript.load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,8 @@ async function FridaInject(options = {}) {
     })
 
     debugLog('[*] Loading frida script')
-    options.onLoad && options.onLoad(fridaScript)
     await fridaScript.load()
+    options.onLoad && options.onLoad(fridaScript)
 
     debugLog('[*] Frida script loaded')
     


### PR DESCRIPTION
Call `options.onLoad` after awaiting `fridaScript.load` to allow `options.onLoad` to use `post` on the script.

```js
onLoad: (script) =>
{
  script.post(/* ... */);
  // Error: GDBus.Error:re.frida.Error.InvalidOperation: Only loaded scripts may be posted to
}
```